### PR TITLE
Graceful termination of the flow.

### DIFF
--- a/icmp4a/src/main/kotlin/com/marsounjan/icmp4a/Icmp4a.kt
+++ b/icmp4a/src/main/kotlin/com/marsounjan/icmp4a/Icmp4a.kt
@@ -296,7 +296,7 @@ class Icmp4a : Icmp {
 
                     delay(retryDelayMillis)
                 }
-                cancel(message = "Processed all of requested $count Echo messages")
+                close()
             } finally {
                 try {
                     Os.close(fd)


### PR DESCRIPTION
By using cancel an exception is thrown and forces the use of .catch operator to handle it even in normal executions.

#before:
icmp.pingInterval(...)
.collect(..)
finalMethod() // final method not executed

#needs:
icmp.pingInterval(...)
.catch{finalMethod()}
.collect(..)
finalMethod() // final method not executed

#with close instead of cancel
icmp.pingInterval(...)
.collect(..)
finalMethod() // final method is executed